### PR TITLE
Add Cluster Name Attributes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,8 @@ provisioner:
             es1:
               private_ip: 127.0.0.1
     elasticsearch:
+      cluster:
+        name: elasticsearch-cluster
       node:
         name: es1
       discovery:

--- a/.octopolo.yml
+++ b/.octopolo.yml
@@ -1,2 +1,2 @@
 deploy_branch: master
-github_repo: sportngin/elasticsearch
+github_repo: sportngin-cookbooks/elasticsearch

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,9 @@ default.elasticsearch[:allocated_memory] = "#{[half_memory_mb, 30500].min}m"
 
 default.elasticsearch[:thread_stack_size] = "256k"
 
+# === CLUSTER
+default.elasticsearch[:cluster][:name] = 'elasticsearch'
+
 # === NODE
 default.elasticsearch[:node][:name] = nil
 

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -29,7 +29,7 @@
 # Cluster name identifies your cluster for auto-discovery. If you're running
 # multiple clusters on the same network, make sure you're using unique names.
 #
-cluster.name: elasticsearch
+cluster.name: <%= node[:elasticsearch][:cluster][:name] %>
 
 
 #################################### Node #####################################

--- a/test/integration/default/serverspec/elasticsearch_spec.rb
+++ b/test/integration/default/serverspec/elasticsearch_spec.rb
@@ -32,6 +32,7 @@ end
 describe file('/data/elasticsearch/config/elasticsearch.yml') do
   it { should be_file }
   its(:content) { should include 'elasticsearch' }
+  its(:content) { should match /^node.cluster: "elasticsearch-cluster"/ }
   its(:content) { should match /^node.name: "es1"/ }
   its(:content) { should match /^node.master: true/ }
   its(:content) { should match /^node.data: true/ }

--- a/test/integration/default/serverspec/elasticsearch_spec.rb
+++ b/test/integration/default/serverspec/elasticsearch_spec.rb
@@ -32,7 +32,7 @@ end
 describe file('/data/elasticsearch/config/elasticsearch.yml') do
   it { should be_file }
   its(:content) { should include 'elasticsearch' }
-  its(:content) { should match /^node.cluster: "elasticsearch-cluster"/ }
+  its(:content) { should match /^node.cluster: elasticsearch-cluster/ }
   its(:content) { should match /^node.name: "es1"/ }
   its(:content) { should match /^node.master: true/ }
   its(:content) { should match /^node.data: true/ }

--- a/test/integration/default/serverspec/elasticsearch_spec.rb
+++ b/test/integration/default/serverspec/elasticsearch_spec.rb
@@ -32,7 +32,7 @@ end
 describe file('/data/elasticsearch/config/elasticsearch.yml') do
   it { should be_file }
   its(:content) { should include 'elasticsearch' }
-  its(:content) { should match /^node.cluster: elasticsearch-cluster/ }
+  its(:content) { should match /^cluster.name: elasticsearch-cluster/ }
   its(:content) { should match /^node.name: "es1"/ }
   its(:content) { should match /^node.master: true/ }
   its(:content) { should match /^node.data: true/ }


### PR DESCRIPTION
Description and Impact
----------------------
> What impact does this change have for production?

Allows the use of a custom cluster name via the `[:cluster][:name]` attribute.


Rollback Plan
-------------
* To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.
