### PR TITLE
Change init script to run elasticsearch in daemon mode

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 site :opscode
 
+cookbook 'apt', '= 3.0.0'
+cookbook 'java', '= 1.39.0'
 metadata

--- a/templates/default/elasticsearch.init.erb
+++ b/templates/default/elasticsearch.init.erb
@@ -32,7 +32,7 @@ start() {
     fi
 
     echo -e "\033[1mStarting elasticsearch...\033[0m"
-    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE <%= node[:elasticsearch][:command_path] %> -p $PIDFILE"
+    su <%= node[:elasticsearch][:user] %> -c "ES_INCLUDE=$ES_INCLUDE <%= node[:elasticsearch][:command_path] %> -p $PIDFILE -d"
 
     return $?
 }

--- a/test/integration/default/serverspec/elasticsearch_spec.rb
+++ b/test/integration/default/serverspec/elasticsearch_spec.rb
@@ -9,6 +9,10 @@ describe service('elasticsearch') do
   it { should be_running }
 end
 
+describe process('bash /etc/init.d/elasticsearch') do
+  it { should_not be_running }
+end
+
 describe command('curl -s localhost:9200') do
   its(:stdout) { should include '"status" : 200,'}
   its(:stdout) { should include '"number" : "1.5.2",'}


### PR DESCRIPTION
Currently elasticsearch process starts in the foreground.  This change will enable daemon mode so the init script doesn't keep running.

Berksfile was updated to lock versions to avoid Chef 12 dependencies.